### PR TITLE
ignore jupyter files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 .pydevproject
 
 examples/data
+
+# Jupyter Notebook
+.ipynb_checkpoints


### PR DESCRIPTION
If the lib is launched with jupyter, .ipynb_checkpoints are created everywhere